### PR TITLE
changes to support hacky undo

### DIFF
--- a/src/Libraries/CoreNodeModels/Input/ColorPalette.cs
+++ b/src/Libraries/CoreNodeModels/Input/ColorPalette.cs
@@ -35,6 +35,7 @@ namespace CoreNodeModels.Input
             {                              
                 dscolor = value;
                 OnNodeModified();
+                RaisePropertyChanged("dsColor");
             }
         }
         /// <summary>
@@ -116,7 +117,7 @@ namespace CoreNodeModels.Input
         /// <returns></returns>
         public override string ToString()
         {
-            return string.Format("Color(Alpha = {3}, Red = {0}, Green = {1}, Blue = {2})", dsColor.Alpha, dsColor.Red, dsColor.Green, dsColor.Blue);
+            return string.Format("Color(Alpha = {0}, Red = {1}, Green = {2}, Blue = {3})", dsColor.Alpha, dsColor.Red, dsColor.Green, dsColor.Blue);
         }
     }
 }

--- a/src/Libraries/CoreNodeModelsWpf/Controls/ColorPalette.xaml
+++ b/src/Libraries/CoreNodeModelsWpf/Controls/ColorPalette.xaml
@@ -9,6 +9,6 @@
              d:DesignHeight="30" d:DesignWidth="90">
 
     <Grid>
-        <xctk:ColorPicker HorizontalAlignment="Center" Margin="0,0,0,0" VerticalAlignment="Center" Width="80" SelectedColor="{Binding MColor , Mode=TwoWay}" AvailableColorsHeader="Standard Colors" ShowStandardColors="False" ShowRecentColors="True" RecentColorsHeader="Recent Colors" SelectedColorChanged="On_Change"/>
+        <xctk:ColorPicker HorizontalAlignment="Center" Margin="0,0,0,0" VerticalAlignment="Center" Width="80" SelectedColor="{Binding MColor , Mode=TwoWay}" AvailableColorsHeader="Standard Colors" ShowStandardColors="False" ShowRecentColors="True" RecentColorsHeader="Recent Colors" SelectedColorChanged="On_Change" />
     </Grid>
 </UserControl>

--- a/src/Libraries/CoreNodeModelsWpf/Controls/ColorPalette.xaml.cs
+++ b/src/Libraries/CoreNodeModelsWpf/Controls/ColorPalette.xaml.cs
@@ -5,6 +5,7 @@ using Dynamo.Graph.Workspaces;
 using Dynamo.Models;
 using Dynamo.UI;
 using Dynamo.ViewModels;
+using System;
 
 namespace CoreNodeModelsWpf.Controls
 
@@ -25,9 +26,8 @@ namespace CoreNodeModelsWpf.Controls
         
         private void On_Change(object sender, System.Windows.RoutedPropertyChangedEventArgs<System.Windows.Media.Color?> e)
         {
-            var undoRecorder = ui.ViewModel.WorkspaceViewModel.Model.UndoRecorder;           
-            WorkspaceModel.RecordModelForModification(nodeModel, undoRecorder);      
+              var undoRecorder = ui.ViewModel.WorkspaceViewModel.Model.UndoRecorder;   
+              WorkspaceModel.RecordModelForModification(nodeModel, undoRecorder);      
         }
-        
     }
 }

--- a/src/Libraries/CoreNodeModelsWpf/NodeViewCustomizations/ColorPalette.cs
+++ b/src/Libraries/CoreNodeModelsWpf/NodeViewCustomizations/ColorPalette.cs
@@ -26,9 +26,13 @@ namespace CoreNodeModelsWpf.Nodes
             get { return mcolor; }
             set
             {
-                mcolor = value;
-                colorPaletteNode.dsColor = DSColor.ByARGB(mcolor.A, mcolor.R, mcolor.G, mcolor.B);
-                RaisePropertyChanged("MColor");
+                if(mcolor != value)
+                {
+                    mcolor = value;
+                    colorPaletteNode.dsColor = DSColor.ByARGB(mcolor.A, mcolor.R, mcolor.G, mcolor.B);
+                    RaisePropertyChanged("MColor");
+                }
+               
             }
         }
         /// <summary>
@@ -40,10 +44,23 @@ namespace CoreNodeModelsWpf.Nodes
         {
             colorPaletteNode = model;
             mcolor = Color.FromArgb(model.dsColor.Alpha, model.dsColor.Red, model.dsColor.Green, model.dsColor.Blue);
+            model.PropertyChanged += Model_PropertyChanged;
             ColorPaletteUINode = new ColorPaletteUI(model, nodeView);
             nodeView.inputGrid.Children.Add(ColorPaletteUINode);
             ColorPaletteUINode.DataContext = this;
         }
+
+        private void Model_PropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)
+        {
+           if(e.PropertyName == "dsColor")
+            {
+                this.MColor = Color.FromArgb(this.colorPaletteNode.dsColor.Alpha,
+                    this.colorPaletteNode.dsColor.Red,
+                    this.colorPaletteNode.dsColor.Green,
+                    this.colorPaletteNode.dsColor.Blue);
+            }
+        }
+
         /// <summary>
         ///     Dispose.
         /// </summary>


### PR DESCRIPTION
@Gytaco please see the diff below to see the changes I made to get undo working. We can follow up here or ever email.

but a few important things:

* I raise a property change event when the model property dsColor changes.
* this is hooked up via a subscription in the nodeView customization to update the MColor value which kicks off the wpf view update.
* This is not so great! 😉  Instead what should be done is that your view should be bound to your model, not to a property on the other view... (NodeViewCustomization) I would guess you can use a converter to convert between the colors inside the binding. That way you're hooked directly up to the model dscolor property instead of having another property inbetween them.... Just a suggestion, if you don't do this you'll need to make sure to unsubscribe the event on dispose of the customization.

* undo requires two undo commands (ctrl+z) each time to undo 1 color change - this is because you are adding the color change command to undo after the color has already changed, so it is adding a command into the undo stack to change into the same color as is already set.
